### PR TITLE
feat(cb2-10795): enable sending of email upon generating a certificate

### DIFF
--- a/src/models/adrPassCertificate.ts
+++ b/src/models/adrPassCertificate.ts
@@ -41,7 +41,7 @@ export type AdrCert = {
 
 export class AdrPassCertificateDocument extends DocumentModel {
   constructor(request: Request) {
-    super('');
+    super(request.recipientEmailAddress);
     const { techRecord, adrCertificate } = request;
 
     this.setDocumentType(DocumentName.ADR_PASS_CERTIFICATE);
@@ -49,7 +49,6 @@ export class AdrPassCertificateDocument extends DocumentModel {
 
     // S3 metadata
     this.metaData.vin = techRecord.vin;
-    this.metaData['should-email-certificate'] = 'false';
 
     const adrData: AdrCert = {
       // ADR data

--- a/src/models/adrPassCertificate.ts
+++ b/src/models/adrPassCertificate.ts
@@ -47,12 +47,14 @@ export class AdrPassCertificateDocument extends DocumentModel {
     this.setDocumentType(DocumentName.ADR_PASS_CERTIFICATE);
     this.filename = `adr_pass_${techRecord.systemNumber}_${adrCertificate.generatedTimestamp}`;
 
+    const totalCerts = techRecord.techRecord_adrPassCertificateDetails?.length ?? 1;
+
     // S3 metadata
     this.metaData.vin = techRecord.vin;
     this.metaData.vrms = techRecord.techRecord_vehicleType === 'trl' ? techRecord.trailerId : techRecord.primaryVrm;
     this.metaData['cert-type'] = 'ADR01C';
-    this.metaData['cert-index'] = techRecord.techRecord_adrPassCertificateDetails.length.toString();
-    this.metaData['total-certs'] = techRecord.techRecord_adrPassCertificateDetails.length.toString();
+    this.metaData['cert-index'] = totalCerts.toString();
+    this.metaData['total-certs'] = totalCerts.toString();
     this.metaData['test-type-name'] = 'ADR';
     this.metaData['test-type-result'] = adrCertificate.certificateType.toLowerCase();
 

--- a/src/models/adrPassCertificate.ts
+++ b/src/models/adrPassCertificate.ts
@@ -49,6 +49,11 @@ export class AdrPassCertificateDocument extends DocumentModel {
 
     // S3 metadata
     this.metaData.vin = techRecord.vin;
+    this.metaData.vrms = techRecord.techRecord_vehicleType === 'trl' ? techRecord.trailerId : techRecord.primaryVrm;
+    this.metaData['cert-type'] = 'ADR01C';
+    this.metaData['cert-index'] = '1';
+    this.metaData['test-type-name'] = 'ADR';
+    this.metaData['test-type-result'] = adrCertificate.certificateType.toLowerCase();
 
     const adrData: AdrCert = {
       // ADR data

--- a/src/models/adrPassCertificate.ts
+++ b/src/models/adrPassCertificate.ts
@@ -51,7 +51,7 @@ export class AdrPassCertificateDocument extends DocumentModel {
 
     // S3 metadata
     this.metaData.vin = techRecord.vin;
-    this.metaData.vrms = techRecord.techRecord_vehicleType === 'trl' ? techRecord.trailerId : techRecord.primaryVrm;
+    this.metaData.vrm = techRecord.techRecord_vehicleType === 'trl' ? techRecord.trailerId : techRecord.primaryVrm;
     this.metaData['cert-type'] = 'ADR01C';
     this.metaData['cert-index'] = totalCerts.toString();
     this.metaData['total-certs'] = totalCerts.toString();

--- a/src/models/adrPassCertificate.ts
+++ b/src/models/adrPassCertificate.ts
@@ -51,12 +51,13 @@ export class AdrPassCertificateDocument extends DocumentModel {
     this.metaData.vin = techRecord.vin;
     this.metaData.vrms = techRecord.techRecord_vehicleType === 'trl' ? techRecord.trailerId : techRecord.primaryVrm;
     this.metaData['cert-type'] = 'ADR01C';
-    this.metaData['cert-index'] = '1';
+    this.metaData['cert-index'] = techRecord.techRecord_adrPassCertificateDetails.length.toString();
+    this.metaData['total-certs'] = techRecord.techRecord_adrPassCertificateDetails.length.toString();
     this.metaData['test-type-name'] = 'ADR';
     this.metaData['test-type-result'] = adrCertificate.certificateType.toLowerCase();
 
+    // ADR data
     const adrData: AdrCert = {
-      // ADR data
       vin: techRecord.vin,
       make: techRecord.techRecord_vehicleType === 'lgv' ? '' : techRecord.techRecord_make,
       vrm: techRecord.techRecord_vehicleType === 'trl' ? techRecord.trailerId : techRecord.primaryVrm,

--- a/tests/unit/adrPassCertificate.test.ts
+++ b/tests/unit/adrPassCertificate.test.ts
@@ -32,8 +32,7 @@ describe('Document Model tests', () => {
     const document = new AdrPassCertificateDocument(request);
 
     expect(document.metaData['document-type']).toBe(DocumentName.ADR_PASS_CERTIFICATE);
-    expect(document.metaData['should-email-certificate']).toBe('false');
     expect(document.metaData.vin).toBe(request.techRecord.vin);
-    expect(document.metaData.email).toBe('');
+    expect(document.metaData.email).toBe('customer@example.com');
   });
 });

--- a/tests/unit/adrPassCertificate.test.ts
+++ b/tests/unit/adrPassCertificate.test.ts
@@ -1,3 +1,4 @@
+import { ADRCertificateTypes } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrCertificateTypes.enum.js';
 import { DocumentName } from '../../src/enums/documentName.enum';
 import { AdrPassCertificateDocument } from '../../src/models/adrPassCertificate';
 import { Request } from '../../src/models/request';
@@ -15,8 +16,7 @@ describe('Document Model tests', () => {
         createdByName: 'mr example',
         generatedTimestamp: new Date().toISOString(),
         certificateId: 'adrPass_1234567_123456',
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        certificateType: 'PASS' as any,
+        certificateType: ADRCertificateTypes.PASS,
       },
     };
   });


### PR DESCRIPTION
## Email generated ADR certificate PDF to logged in user

Enables emailing the PDF of the generated ADR certificate during an ADR test.

[https://dvsa.atlassian.net/browse/CB2-10795](https://dvsa.atlassian.net/browse/CB2-10795)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number